### PR TITLE
Use default PIL font if segoeui not available

### DIFF
--- a/animaloc/vizual/objects.py
+++ b/animaloc/vizual/objects.py
@@ -61,7 +61,10 @@ def draw_text(
     )-> PIL.Image.Image:
 
     draw = ImageDraw.Draw(image)
-    font = ImageFont.truetype("segoeui.ttf", size=font_size)
+    try:
+        font = ImageFont.truetype("segoeui.ttf", size=font_size)
+    except IOError:
+        font = ImageFont.load_default()
 
     l, t, r, b = draw.textbbox(position, text, font=font)
     draw.rectangle((l-5, t-5, r+5, b+5), fill='white')


### PR DESCRIPTION
On MacOS font wasn't available by default, this uses the built-in PIL bitmap font.