### PR TITLE
fix: return coordinates to its original scale when using stitcher

### DIFF
--- a/animaloc/eval/evaluators.py
+++ b/animaloc/eval/evaluators.py
@@ -369,6 +369,27 @@ class HerdNetEvaluator(Evaluator):
         
         return dict(gt = gt, preds = preds, est_count = counts[0])
 
+    @property
+    def detections(self) -> pandas.DataFrame:
+        ''' Returns detections (image id, location, label and score) in a pandas
+        dataframe with coordinates scaled to original image space when using stitcher '''
+
+        assert self._stored_metrics is not None, \
+            'No detections have been stored, please use the evaluate method first.'
+
+        img_names = self.dataloader.dataset._img_names
+        dets = self._stored_metrics.detections.copy()
+
+        for det in dets:
+            det['images'] = img_names[det['images']]
+
+            # Scale coordinates to original image space when using stitcher
+            if self.stitcher is not None and 'x' in det and 'y' in det:
+                det['x'] = det['x'] * self.stitcher.down_ratio
+                det['y'] = det['y'] * self.stitcher.down_ratio
+
+        return pandas.DataFrame(data = dets)
+
 @EVALUATORS.register()
 class DensityMapEvaluator(Evaluator):
   


### PR DESCRIPTION
Hello, first of all, thanks for making this repo open source, I have learned a lot from it 🙏

When I ran the testing pipeline, I noticed that detections weren’t properly calculated. This happens because of a small bug in the detection point calculation, which doesn’t take into account the stitcher’s original downsampling. In the end, points must be upscaled to fit the original image size when a stitcher is used.

Feel free to share any comments about things I should change to get the fix right. Once again, thanks for this useful and instructive repo 🙏

I attach two images with the before and after

<img width="511" height="516" alt="image" src="https://github.com/user-attachments/assets/d9e0895b-31ab-4685-be28-02aac834ef09" />

<img width="511" height="516" alt="image" src="https://github.com/user-attachments/assets/1885f7d4-464e-4870-af20-da054b5e8374" />

Also the code used on the evaluator when testing the solution and the error:

```python
down_ratio = 2
test_dataset = CSVDataset(
    csv_file = f'{ROOT_DIR}/val_patches/gt.csv',
    root_dir = f'{ROOT_DIR}/val_patches',
    albu_transforms = [A.Normalize(p=1.0)],
    end_transforms = [DownSample(down_ratio=down_ratio, anno_type='point')]
    )

test_dataloader = DataLoader(dataset = test_dataset, batch_size = 1, shuffle = False, num_workers=8)

test_evaluator = HerdNetEvaluator(
    model=herdnet,
    dataloader=test_dataloader,
    metrics=metrics,
    stitcher=stitcher,
    work_dir=test_dir,
    header='test'
    )
    
test_f1_score = test_evaluator.evaluate(returns='f1_score')

test_evaluator.detections.to_csv("test_evaluator_detections.csv")
```